### PR TITLE
feat: implement blue-green deployment for pbfUrl changes

### DIFF
--- a/config/crd/bases/osrm.itayankri_osrmclusters.yaml
+++ b/config/crd/bases/osrm.itayankri_osrmclusters.yaml
@@ -424,6 +424,10 @@ spec:
           status:
             description: OSRMClusterStatus defines the observed state of OSRMCluster
             properties:
+              activeEnvironment:
+                description: ActiveEnvironment indicates which environment (blue/green)
+                  is currently serving traffic
+                type: string
               conditions:
                 items:
                   description: Condition contains details for one aspect of the current
@@ -480,6 +484,10 @@ spec:
                   - type
                   type: object
                 type: array
+              currentPbfUrlHash:
+                description: CurrentPbfUrlHash is the hash of the currently active
+                  pbfUrl
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed
                   by the operator.
@@ -490,6 +498,10 @@ spec:
                 type: boolean
               phase:
                 description: Phase is the current phase of the deployment
+                type: string
+              updatingEnvironment:
+                description: UpdatingEnvironment indicates which environment is being
+                  updated with new pbfUrl
                 type: string
             type: object
         type: object

--- a/internal/metadata/labels.go
+++ b/internal/metadata/labels.go
@@ -18,13 +18,22 @@ const NameLabelKey = "app.kubernetes.io/name"
 const PartOfLabelKey = "app.kubernetes.io/part-of"
 const ComponentLabelKey = "app.kubernetes.io/component"
 const GenerationLabelKey = "osrmcluster.itayankri/cluster-generation"
+const EnvironmentLabelKey = "osrmcluster.itayankri/environment"
 
 func GetLabels(instance *osrmv1alpha1.OSRMCluster, componentName ComponentLabelValue) map[string]string {
+	return GetLabelsWithEnvironment(instance, componentName, "")
+}
+
+func GetLabelsWithEnvironment(instance *osrmv1alpha1.OSRMCluster, componentName ComponentLabelValue, environment string) map[string]string {
 	labels := map[string]string{
 		NameLabelKey:       instance.Name,
 		PartOfLabelKey:     "osrmcluster",
 		ComponentLabelKey:  string(componentName),
 		GenerationLabelKey: strconv.FormatInt(instance.ObjectMeta.Generation, 10),
+	}
+
+	if environment != "" {
+		labels[EnvironmentLabelKey] = environment
 	}
 
 	for label, value := range instance.Labels {

--- a/internal/resource/osrm_resource_builder.go
+++ b/internal/resource/osrm_resource_builder.go
@@ -15,8 +15,9 @@ type ResourceBuilder interface {
 }
 
 type OSRMResourceBuilder struct {
-	Instance *osrmv1alpha1.OSRMCluster
-	Scheme   *runtime.Scheme
+	Instance    *osrmv1alpha1.OSRMCluster
+	Scheme      *runtime.Scheme
+	Environment string
 }
 
 type ProfileScopedBuilder struct {
@@ -49,5 +50,17 @@ func (builder *OSRMResourceBuilder) ResourceBuilders() []ResourceBuilder {
 		}...)
 	}
 
+	return builders
+}
+
+func (builder *OSRMResourceBuilder) EnvironmentResourceBuilders() []ResourceBuilder {
+	builders := []ResourceBuilder{}
+	for _, profile := range builder.Instance.Spec.Profiles {
+		builders = append(builders, []ResourceBuilder{
+			builder.PersistentVolumeClaimWithEnvironment(profile),
+			builder.JobWithEnvironment(profile),
+			builder.DeploymentWithEnvironment(profile),
+		}...)
+	}
 	return builders
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -131,3 +131,17 @@ func DoAllReplicasReady(resources []runtime.Object) bool {
 	}
 	return allReplicasReady
 }
+
+func IsDeploymentReady(deploymentName string, resources []runtime.Object) bool {
+	for _, resource := range resources {
+		if deployment, ok := resource.(*appsv1.Deployment); ok {
+			if deployment != nil && deployment.ObjectMeta.Name == deploymentName {
+				if deployment.Spec.Replicas != nil && deployment.Status.ReadyReplicas >= *deployment.Spec.Replicas {
+					return true
+				}
+				return false
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This commit introduces blue-green deployment support for seamless map updates when the pbfUrl field in OSRMCluster resources changes. The implementation ensures zero-downtime updates by creating parallel environments and switching traffic only after the new environment is fully ready.

Key features:
- Environment tracking with blue/green labels and status fields
- Automatic pbfUrl change detection using SHA256 hashing
- Environment-specific resource creation (PVC, Jobs, Deployments)
- Automatic traffic switching via service selector updates
- Cleanup of old environment resources after successful deployment

Changes:
- Add blue-green status fields to OSRMClusterStatus
- Extend resource builders with environment-aware naming and labeling
- Implement blue-green orchestration logic in controller
- Add deployment readiness checking functionality
- Update CRD schema with new status fields

The operator will now automatically detect pbfUrl changes and orchestrate a complete blue-green deployment, ensuring continuous service availability during map data updates.

🤖 Generated with [Claude Code](https://claude.ai/code)